### PR TITLE
Try and make use of 'ee' permanent

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.34mas"
+LEVELDB_VSN="2.0.34ee"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -56,7 +56,7 @@ case "$1" in
 
     get-deps)
         if [ ! -d leveldb ]; then
-            git clone git://github.com/basho/leveldb
+            git clone git://github.com/martinsumner/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             (cd leveldb && git submodule update --init)
         fi
@@ -81,7 +81,7 @@ case "$1" in
         export LEVELDB_VSN="$LEVELDB_VSN"
 
         if [ ! -d leveldb ]; then
-            git clone git://github.com/basho/leveldb
+            git clone git://github.com/martinsumner/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             (cd leveldb && git submodule update --init)
         fi

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.34"
+LEVELDB_VSN="2.0.34mas"
 
 SNAPPY_VSN="1.0.4"
 
@@ -56,7 +56,7 @@ case "$1" in
 
     get-deps)
         if [ ! -d leveldb ]; then
-            git clone git://github.com/basho/leveldb
+            git clone git://github.com/martinsumner/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             (cd leveldb && git submodule update --init)
         fi
@@ -81,7 +81,7 @@ case "$1" in
         export LEVELDB_VSN="$LEVELDB_VSN"
 
         if [ ! -d leveldb ]; then
-            git clone git://github.com/basho/leveldb
+            git clone git://github.com/martinsumner/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             (cd leveldb && git submodule update --init)
         fi

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -8,7 +8,7 @@ if [ `uname -s` = 'SunOS' -a "${POSIX_SHELL}" != "true" ]; then
 fi
 unset POSIX_SHELL # clear it so if we invoke other scripts, they run as ksh as well
 
-LEVELDB_VSN="2.0.34ee"
+LEVELDB_VSN="2.0.34nhs"
 
 SNAPPY_VSN="1.0.4"
 

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -56,7 +56,7 @@ case "$1" in
 
     get-deps)
         if [ ! -d leveldb ]; then
-            git clone git://github.com/martinsumner/leveldb
+            git clone git://github.com/basho/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             (cd leveldb && git submodule update --init)
         fi
@@ -81,7 +81,7 @@ case "$1" in
         export LEVELDB_VSN="$LEVELDB_VSN"
 
         if [ ! -d leveldb ]; then
-            git clone git://github.com/martinsumner/leveldb
+            git clone git://github.com/basho/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             (cd leveldb && git submodule update --init)
         fi

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -58,9 +58,7 @@ case "$1" in
         if [ ! -d leveldb ]; then
             git clone git://github.com/basho/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
-            if [ "$BASHO_EE" = "1" ]; then
-                (cd leveldb && git submodule update --init)
-            fi
+            (cd leveldb && git submodule update --init)
         fi
         ;;
 
@@ -85,9 +83,7 @@ case "$1" in
         if [ ! -d leveldb ]; then
             git clone git://github.com/basho/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
-            if [ $BASHO_EE = "1" ]; then
-                (cd leveldb && git submodule update --init)
-            fi
+            (cd leveldb && git submodule update --init)
         fi
 
         # hack issue where high level make is running -j 4

--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -56,7 +56,7 @@ case "$1" in
 
     get-deps)
         if [ ! -d leveldb ]; then
-            git clone git://github.com/martinsumner/leveldb
+            git clone https://github.com/martinsumner/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             (cd leveldb && git submodule update --init)
         fi
@@ -81,7 +81,7 @@ case "$1" in
         export LEVELDB_VSN="$LEVELDB_VSN"
 
         if [ ! -d leveldb ]; then
-            git clone git://github.com/martinsumner/leveldb
+            git clone https://github.com/martinsumner/leveldb
             (cd leveldb && git checkout $LEVELDB_VSN)
             (cd leveldb && git submodule update --init)
         fi


### PR DESCRIPTION
This appears to work:

```
==> eleveldb (get-deps)
Cloning into 'leveldb'...
Note: checking out '2.0.34'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at d6507aa merge mv-hot-backup2 bug fix to 2.0
Submodule 'leveldb_ee' (git@github.com:basho/leveldb_ee) registered for path 'leveldb_ee'
Cloning into '/Users/martinsumner/dbroot/riak/deps/eleveldb/c_src/leveldb/leveldb_ee'...
Submodule path 'leveldb_ee': checked out '1d13c28cb198770e03f805c7dd32d6a58260c1e2'
```

Are there any issues with moving people who weren't previously on `ee` to `ee`?  Does this need to remain an option in some way (even maybe maintaining a branch that can regress to non-`ee`)?